### PR TITLE
remove compiled prefix from stored contract code

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,7 @@ Account.prototype.getCode = function (state, cb) {
     return
   }
 
-  state.getRaw(this.codeHash, function (err, val) {
-    cb(err, val)
-  })
+  state.getRaw(this.codeHash, cb)
 }
 
 Account.prototype.setCode = function (trie, code, cb) {

--- a/index.js
+++ b/index.js
@@ -37,27 +37,14 @@ Account.prototype.getCode = function (state, cb) {
   }
 
   state.getRaw(this.codeHash, function (err, val) {
-    var compiled = val[0] === 1
-    val = val.slice(1)
-    cb(err, val, compiled)
+    cb(err, val)
   })
 }
 
-Account.prototype.setCode = function (trie, code, compiled, cb) {
+Account.prototype.setCode = function (trie, code, cb) {
   var self = this
 
-  if (arguments.length === 3) {
-    cb = compiled
-    compiled = false
-  }
-
-  // store code for a new contract
-  if (!compiled) {
-    this.codeHash = ethUtil.sha3(code)
-  }
-
-  // set the compile flag
-  code = Buffer.concat([new Buffer([compiled]), code])
+  this.codeHash = ethUtil.sha3(code)
 
   if (this.codeHash.toString('hex') === ethUtil.SHA3_NULL_S) {
     cb(null, new Buffer([]))


### PR DESCRIPTION
This removes `00` prefix for contract-code stored in leveldb. 
This unused prefix breaks the property: `sha(value) = key` which causes problems with working across implementations on database-level.
