### PR TITLE
Make Account Object an ES6-compatible Class

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,79 +2,83 @@ const ethUtil = require('ethereumjs-util')
 const rlp = require('rlp')
 const Buffer = require('safe-buffer').Buffer
 
-var Account = module.exports = function (data) {
-  // Define Properties
-  var fields = [{
-    name: 'nonce',
-    default: Buffer.alloc(0)
-  }, {
-    name: 'balance',
-    default: Buffer.alloc(0)
-  }, {
-    name: 'stateRoot',
-    length: 32,
-    default: ethUtil.SHA3_RLP
-  }, {
-    name: 'codeHash',
-    length: 32,
-    default: ethUtil.SHA3_NULL
-  }]
-
-  ethUtil.defineProperties(this, fields, data)
-}
-
-Account.prototype.serialize = function () {
-  return rlp.encode(this.raw)
-}
-
-Account.prototype.isContract = function () {
-  return this.codeHash.toString('hex') !== ethUtil.SHA3_NULL_S
-}
-
-Account.prototype.getCode = function (state, cb) {
-  if (!this.isContract()) {
-    cb(null, Buffer.alloc(0))
-    return
+class Account {
+  constructor (data) {
+    // Define Properties
+    let fields = [{
+      name: 'nonce',
+      default: Buffer.alloc(0)
+    }, {
+      name: 'balance',
+      default: Buffer.alloc(0)
+    }, {
+      name: 'stateRoot',
+      length: 32,
+      default: ethUtil.SHA3_RLP
+    }, {
+      name: 'codeHash',
+      length: 32,
+      default: ethUtil.SHA3_NULL
+    }]
+  
+    ethUtil.defineProperties(this, fields, data)
   }
 
-  state.getRaw(this.codeHash, cb)
-}
-
-Account.prototype.setCode = function (trie, code, cb) {
-  var self = this
-
-  this.codeHash = ethUtil.sha3(code)
-
-  if (this.codeHash.toString('hex') === ethUtil.SHA3_NULL_S) {
-    cb(null, Buffer.alloc(0))
-    return
+  serialize () {
+    return rlp.encode(this.raw)
   }
 
-  trie.putRaw(this.codeHash, code, function (err) {
-    cb(err, self.codeHash)
-  })
+  isContract () {
+    return this.codeHash.toString('hex') !== ethUtil.SHA3_NULL_S
+  }
+
+  getCode (state, cb) {
+    if (!this.isContract()) {
+      cb(null, Buffer.alloc(0))
+      return
+    }
+  
+    state.getRaw(this.codeHash, cb)
+  }
+
+  setCode (trie, code, cb) {
+    let self = this
+  
+    this.codeHash = ethUtil.sha3(code)
+  
+    if (this.codeHash.toString('hex') === ethUtil.SHA3_NULL_S) {
+      cb(null, Buffer.alloc(0))
+      return
+    }
+  
+    trie.putRaw(this.codeHash, code, function (err) {
+      cb(err, self.codeHash)
+    })
+  }
+
+  getStorage (trie, key, cb) {
+    let t = trie.copy()
+    t.root = this.stateRoot
+    t.get(key, cb)
+  }
+
+  setStorage (trie, key, val, cb) {
+    let self = this
+    let t = trie.copy()
+    t.root = self.stateRoot
+    t.put(key, val, function (err) {
+      if (err) return cb()
+      self.stateRoot = t.root
+      cb()
+    })
+  }
+
+  isEmpty () {
+    return this.balance.toString('hex') === '' &&
+    this.nonce.toString('hex') === '' &&
+    this.stateRoot.toString('hex') === ethUtil.SHA3_RLP_S &&
+    this.codeHash.toString('hex') === ethUtil.SHA3_NULL_S
+  }
 }
 
-Account.prototype.getStorage = function (trie, key, cb) {
-  var t = trie.copy()
-  t.root = this.stateRoot
-  t.get(key, cb)
-}
-
-Account.prototype.setStorage = function (trie, key, val, cb) {
-  var self = this
-  var t = trie.copy()
-  t.root = self.stateRoot
-  t.put(key, val, function (err) {
-    if (err) return cb()
-    self.stateRoot = t.root
-    cb()
-  })
-}
-
-Account.prototype.isEmpty = function () {
-  return this.balance.toString('hex') === '' &&
-  this.nonce.toString('hex') === '' &&
-  this.stateRoot.toString('hex') === ethUtil.SHA3_RLP_S &&
-  this.codeHash.toString('hex') === ethUtil.SHA3_NULL_S
-}
+module.exports = Account


### PR DESCRIPTION
Moving `Account` from an object with prototype-defined functions to an ES6-esque class with member functions.