### PR TITLE
chore(package): update @types/node to version 11.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ethereumjs/config-tsc": "^1.1.0",
     "@ethereumjs/config-tslint": "^1.1.0",
     "@types/bn.js": "^4.11.3",
-    "@types/node": "^10.12.18",
+    "@types/node": "^11.9.4",
     "@types/tape": "^4.2.33",
     "coveralls": "^3.0.0",
     "nyc": "^13.2.0",


### PR DESCRIPTION
Closes #36 

Using this new PR for convenience since the old Greenkeeper PR has no rebase/branch update functionality https://github.com/ethereumjs/ethereumjs-account/pull/36 (this is actually some open issue on Greenkeeper: https://github.com/greenkeeperio/greenkeeper/issues/777).