### PR TITLE
Fixes isEmpty to match EIP-161

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Note that the library is not meant to be used to handle your wallet accounts, us
 `web3.js` library for that. This is just a semantic wrapper to ease the use of account data and
 provide functionality for reading and writing accounts from and to the Ethereum state trie.
 
+Note: The library implements [EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md) to determine empty accounts,
+and as such doesn't support hardforks before the Spurious Dragon.
+
 # INSTALL
 
 `npm install ethereumjs-account`

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,6 @@ export default class Account {
     return (
       this.balance.toString('hex') === '' &&
       this.nonce.toString('hex') === '' &&
-      this.stateRoot.toString('hex') === ethUtil.KECCAK256_RLP_S &&
       this.codeHash.toString('hex') === ethUtil.KECCAK256_NULL_S
     )
   }


### PR DESCRIPTION
According to [EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md):

> An account is considered empty when it has no code and zero nonce and zero balance.

This would fix the `dynamicAccountOverwriteEmpty` test case in VM.