### PR TITLE
Husky pre-push Git hook integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "lint:fix": "ethereumjs-config-lint-fix",
     "test": "ts-node node_modules/tape/bin/tape ./test/index.ts"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "keywords": [
     "ethereum",
     "account"
@@ -50,6 +55,7 @@
     "@types/node": "^11.9.4",
     "@types/tape": "^4.2.33",
     "coveralls": "^3.0.0",
+    "husky": "^1.3.1",
     "nyc": "^13.2.0",
     "prettier": "^1.15.3",
     "tape": "^4.10.1",


### PR DESCRIPTION
This PR adds a simple ``pre-push`` Git hook using the ``Husky`` package as suggested in https://github.com/ethereumjs/ethereumjs-config/issues/16.

This works like a charm 🙏 🎊 - I am already in love - since it will prevent many future double-rounds on community and non-community commits.

I have a tendency to just only add linting - since it is by far the most common cause of initial CI failure - and not add testing, since this might be annoying or limiting at times. Think with linting we are already a lot far better off.

This is an exemplary first appliance, I would go through the other repos and do the integration together with some other work for practicality once this is approved.