### PR TITLE
Changes EIP links to preferred citation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that the library is not meant to be used to handle your wallet accounts, us
 `web3.js` library for that. This is just a semantic wrapper to ease the use of account data and
 provide functionality for reading and writing accounts from and to the Ethereum state trie.
 
-Note: The library implements [EIP-161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md) to determine empty accounts,
+Note: The library implements [EIP-161](https://eips.ethereum.org/EIPS/eip-161) to determine empty accounts,
 and as such doesn't support hardforks before the Spurious Dragon.
 
 # INSTALL


### PR DESCRIPTION
While updating the links across the 6 repos for the migration, I bumped into these different formats for EIP links. As they does not impact the migration, I decided to update them now.

> **Preferred Citation Format [1]**
> The canonical URL for a EIP that has achieved draft status at any point is at https://eips.ethereum.org/. For example, the canonical URL for EIP-1 is https://eips.ethereum.org/EIPS/eip-1.

[Reference](https://github.com/ethereum/EIPs/blob/af677b348da866d41a58d8948a89d0b00d410e2b/README.md#preferred-citation-format).