### PR TITLE
Reverting NYC to 13.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/tape": "^4.2.33",
     "husky": "^2.1.0",
     "merkle-patricia-tree": "^3.0.0",
-    "nyc": "^15.0.0",
+    "nyc": "^13.2.0",
     "prettier": "^1.15.3",
     "tape": "^4.10.1",
     "ts-node": "^7.0.1",


### PR DESCRIPTION
There's a breaking change in `nyc` v15 that generates reports with relative paths.

![](https://media.discordapp.net/attachments/390199760025419777/681919467575705804/unknown.png)

In the monorepo context, reports should contain the `packages/account` path segment, so this won't work for us:
`SF:src/index.ts`

We need to have the former behavior back, with the absolute path:
`SF:/home/circleci/project/packages/account/src/index.ts`
